### PR TITLE
Use the Superuser WP theme for ansible/lampstack. 

### DIFF
--- a/ansible/lampstack/roles/webserver/tasks/main.yml
+++ b/ansible/lampstack/roles/webserver/tasks/main.yml
@@ -8,6 +8,7 @@
     - apache2
     - php5
     - php5-mysql
+    - php5-gd    
     - nfs-common
     - unzip
     - ssmtp

--- a/ansible/lampstack/roles/wordpress/tasks/main.yml
+++ b/ansible/lampstack/roles/wordpress/tasks/main.yml
@@ -19,6 +19,15 @@
     --admin_email='interop@openstack.org'
   when: hostvars.cloud.balancer.openstack.public_v4 == ""
 
+- name: Install package for automated plugin activation
+  shell: >
+    wp package install itspriddle/wp-cli-tgmpa-plugin
+
+- name: Make an initial request, so that later switch-theme hooks work.
+  shell: >
+    sudo -u www-data wp --path=/var/www/html
+    cron test
+
 - name: Activate wordpress theme
   shell: >
     wp --path=/var/www/html theme activate
@@ -37,13 +46,20 @@
   args:
     warn: no
 
+- name: Install and activate required plugins
+  shell: >
+    sudo -u www-data wp --path=/var/www/html
+    tgmpa-plugin install --all-required --activate
+  args:
+    warn: no
+
 - name: Download wordpress sample posts
   get_url:
     url: "{{ app_env.wp_posts }}"
     dest: /tmp/wpposts.zip
     force: yes
 
-- name: Unpack the post
+- name: Unpack the posts
   shell: unzip -o -q /tmp/wpposts.zip -d /tmp/posts
   args:
     warn: no
@@ -52,3 +68,21 @@
   shell: >
     sudo -u www-data wp --path=/var/www/html
     import /tmp/posts/*.xml --authors=create --quiet
+
+- name: Regenerate thumbnails for the imported posts
+  shell: >
+    sudo -u www-data wp --path=/var/www/html
+    media regenerate --yes --quiet
+
+- name: Trigger post-activation hooks
+  shell: >
+    sudo -u www-data wp --path=/var/www/html
+    cron test
+
+- name: Flush rewrite rules, setup htaccess for nice permalinks
+  shell: >
+    sudo -u www-data
+    WP_CLI_CONFIG_PATH=/var/www/html/wp-content/themes/{{ app_env.wp_theme.split('/').pop().split('.')[0] }}/wp-cli.yml
+    wp --path=/var/www/html
+    rewrite flush --hard
+

--- a/ansible/lampstack/vars/osic.yml
+++ b/ansible/lampstack/vars/osic.yml
@@ -20,6 +20,6 @@ app_env: {
   stack_size: 4,
   volume_size: 2,
   block_device_name: "/dev/vdb",
-  wp_theme: "https://downloads.wordpress.org/theme/iribbon.2.0.65.zip",
-  wp_posts: "http://wpcandy.s3.amazonaws.com/resources/postsxml.zip"
+  wp_theme: "http://static.tipit.net/OpenStack/superuser/superuser.zip",
+  wp_posts: "http://static.tipit.net/OpenStack/superuser/superuser_content.xml.zip"
 }


### PR DESCRIPTION
This is for the interop challenge. You could either merge to master, or run the demo directly off this branch, if you find that my tweaks are overly specific.  

Changes to webserver and wordpress tasks:
- Added php5-gd to the apt list, it's required to re-generate thumbnails after importing the posts.
- Added a WP-CLI package for automatic install of plugins required by the theme (via TGM Plugin Activation)
- Ping the site before and after activating the theme, to trigger any after_switch_theme hooks.
- Flush rewrite rules, and setup htaccess for nice permalinks

Even though these task changes were prompted by the Superuser theme, they're safe: they will be positive for any other theme implementing these hooks, and will not error if the hooks aren't available.

This is a shameless PR, in that I haven't actually tested these changes! 😨 
Since I don't have access to cloud right now to test this against, and we're short of time, I went ahead and pushed it for your review and testing.
