### PR TITLE
Parameterize sleep interval

### DIFF
--- a/neutron/l3-agent-evacuate.py
+++ b/neutron/l3-agent-evacuate.py
@@ -135,7 +135,7 @@ def evacuate_l3_agent(api, region, from_agent, to_agent, limit):
         sys.exit(1)
     if limit and (len(ha_false_routers) > limit):
         ha_false_routers = ha_false_routers[0:limit]
-    print "Starting ... Moving a router every 10 seconds\n"
+    print ("Starting ... Moving a router every %s seconds\n" % sleep)
     for r in ha_false_routers:
         r_id = {'router_id': r['id']}
         print "Removing router %s" % r['id']

--- a/neutron/l3-agent-evacuate.py
+++ b/neutron/l3-agent-evacuate.py
@@ -78,7 +78,7 @@ def main():
     if args.router:
         moverouter(api, os_region_name, args.from_l3agent, args.to_l3agent, args.router)
     else:
-        evacuate_l3_agent(api, os_region_name, args.from_l3agent, args.to_l3agent, limit)
+        evacuate_l3_agent(api, os_region_name, args.from_l3agent, args.to_l3agent, limit, args.sleep)
 
 def validateargs(api, region, from_agent, to_agent, router, sleep):
     neutron = api.neutron(region)
@@ -119,7 +119,7 @@ def moverouter(api, region, from_agent, to_agent, router):
     print "Adding   router %s" % router
     neutron.add_router_to_l3_agent(to_agent, r_id)
 
-def evacuate_l3_agent(api, region, from_agent, to_agent, limit):
+def evacuate_l3_agent(api, region, from_agent, to_agent, limit, sleep):
     """Evacuate"""
     neutron = api.neutron(region)
     routers = neutron.list_routers_on_l3_agent(from_agent)["routers"]
@@ -142,7 +142,7 @@ def evacuate_l3_agent(api, region, from_agent, to_agent, limit):
         neutron.remove_router_from_l3_agent(from_agent, r['id'])
         print "Adding   router %s" % r['id']
         neutron.add_router_to_l3_agent(to_agent, r_id)
-        time.sleep(sleep)
+        time.sleep(float(sleep))
 
 
 

--- a/neutron/l3-agent-evacuate.py
+++ b/neutron/l3-agent-evacuate.py
@@ -53,6 +53,7 @@ def main():
     parser.add_argument('-f', '--from-l3agent', help='l3agent uuid', required=True)
     parser.add_argument('-t', '--to-l3agent', help='l3agent uuid', required=True)
     parser.add_argument('-r', '--router', help='specific router')
+    parser.add_argument('-s', '--sleep', help='sleep interval in seconds')
     parser.add_argument('-l', '--limit', help='max number of routers to migrate')
     parser.add_argument('-v', '--verbose', help='verbose', action='store_true')
     args = parser.parse_args()
@@ -72,14 +73,14 @@ def main():
         limit = 0
 
     #Validate agent's UUID
-    validateargs(api, os_region_name, args.from_l3agent, args.to_l3agent, args.router)
+    validateargs(api, os_region_name, args.from_l3agent, args.to_l3agent, args.router, args.sleep)
 
     if args.router:
         moverouter(api, os_region_name, args.from_l3agent, args.to_l3agent, args.router)
     else:
         evacuate_l3_agent(api, os_region_name, args.from_l3agent, args.to_l3agent, limit)
 
-def validateargs(api, region, from_agent, to_agent, router):
+def validateargs(api, region, from_agent, to_agent, router, sleep):
     neutron = api.neutron(region)
     l3_agents_uuids=[]
     routers_uuids=[]
@@ -107,6 +108,8 @@ def validateargs(api, region, from_agent, to_agent, router):
             print "Wrong from_agent for specified router"
             sys.exit(1)
 
+    if sleep < 0:
+        print "Need to have non-negative amount of sleep!"
 
 def moverouter(api, region, from_agent, to_agent, router):
     neutron = api.neutron(region)
@@ -139,7 +142,7 @@ def evacuate_l3_agent(api, region, from_agent, to_agent, limit):
         neutron.remove_router_from_l3_agent(from_agent, r['id'])
         print "Adding   router %s" % r['id']
         neutron.add_router_to_l3_agent(to_agent, r_id)
-        time.sleep(10)
+        time.sleep(sleep)
 
 
 


### PR DESCRIPTION
Instead of the hardcoded 10 seconds, allow user to define a custom interval to sleep between router migrations.